### PR TITLE
verilator_tb_utils: Add utility for determining clk posedge

### DIFF
--- a/verilator_tb_utils.core
+++ b/verilator_tb_utils.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name: ::verilator_tb_utils:1.0
+name: ::verilator_tb_utils:1.1
 description: "Verilator test bench utility class"
 
 filesets:

--- a/verilator_tb_utils.cpp
+++ b/verilator_tb_utils.cpp
@@ -11,7 +11,7 @@
 
 VerilatorTbUtils::VerilatorTbUtils(uint32_t *mem)
   : mem(mem), t(0), timeout(0), vcdDump(false), vcdDumpStart(0), vcdDumpStop(0),
-    vcdFileName((char *)VCD_DEFAULT_NAME), jtagEnable(false),
+    vcdFileName((char *)VCD_DEFAULT_NAME), jtagEnable(false), lastClk(0),
     jtagPort(5555) {
   tfp = new VerilatedVcdC;
   jtag = new VerilatorJtagServer(10); /* Jtag clock is 10 period */
@@ -61,6 +61,12 @@ bool VerilatorTbUtils::doCycle() {
 
   t++;
   return true;
+}
+
+bool VerilatorTbUtils::clkPosEdge(uint8_t clk) {
+  bool isEdge = lastClk == 0 && clk == 1;
+  lastClk = clk;
+  return isEdge;
 }
 
 bool VerilatorTbUtils::loadElf(char *fileName) {

--- a/verilator_tb_utils.h
+++ b/verilator_tb_utils.h
@@ -34,6 +34,7 @@ public:
 
   static int parseOpts(int key, char *arg, struct argp_state *state);
 
+  bool clkPosEdge(uint8_t clk);
 private:
   uint64_t t;
 
@@ -52,6 +53,8 @@ private:
 
   bool loadElf(char *fileName);
   bool loadBin(char *fileName);
+
+  uint8_t lastClk;
 };
 
 #endif


### PR DESCRIPTION
This is to be used in mor1kx-generic where we want to run monitor and trace cycles on posEdge.